### PR TITLE
Enhancement/benchmarking

### DIFF
--- a/tooling/README.md
+++ b/tooling/README.md
@@ -17,3 +17,7 @@ python ./benchmark.py --help
 ```
 
 Running the benchmark depending on your settings and size of dataset might take a while.
+
+## Notes
+
+When using the `--scale-percentage` parameter keep in mind that results of this are only compareable to datasets that are read in the same order.

--- a/tooling/benchmark.py
+++ b/tooling/benchmark.py
@@ -1,14 +1,5 @@
 import argparse
-from jiwer.transforms import (
-    Compose,
-    RemoveMultipleSpaces,
-    Strip,
-    ToLowerCase,
-    ExpandCommonEnglishContractions,
-    RemoveKaldiNonWords,
-    RemoveWhiteSpace,
-    ReduceToSingleSentence,
-)
+
 import tqdm
 import time
 import jiwer
@@ -22,22 +13,11 @@ from helpers.file_helper import (
 from helpers.rest_helper import transcribe_file_rest
 from helpers.websocket_helper import (
     TRANSCRIPTION_WEBSOCKET_TIMEOUT,
+    evaluate_partial_websocket,
     transcribe_file_websocket,
 )
 from helpers.table_helpers import render_table, ERR_CODE
-
-
-transform_default = Compose(
-    [
-        ToLowerCase(),
-        ExpandCommonEnglishContractions(),
-        RemoveKaldiNonWords(),
-        RemoveWhiteSpace(replace_by_space=True),
-        RemoveMultipleSpaces(),
-        Strip(),
-        ReduceToSingleSentence(),
-    ]
-)
+from helpers.WER_helper import TRANSFORM_DEFAULT
 
 
 def benchmark(settings):
@@ -49,13 +29,21 @@ def benchmark(settings):
         "wer_websocket": [],
         "duration_websocket": [],
     }
-    for filepath in tqdm.tqdm(
-        audio_files, desc="Transcribing", disable=settings.disable_progress_bar
+    # calculate upper limit
+    limit = (int(settings.scale_percentage) / 100) * len(audio_files)
+    for count, filepath in enumerate(
+        tqdm.tqdm(
+            audio_files, desc="Transcribing", disable=settings.disable_progress_bar
+        )
     ):
+        if settings.scale_percentage != "100" and count >= limit:
+            break
         rest_transcription = None
         rest_duration = None
         websocket_transcription = None
         websocket_duration = None
+        websocket_partial_result = 0.0
+        expected = TRANSFORM_DEFAULT(get_expected_transcription(filepath))
         if settings.target == "rest" or settings.target == "all":
             start_time = time.time()
             rest_transcription = transcribe_file_rest(
@@ -64,15 +52,19 @@ def benchmark(settings):
             rest_duration = time.time() - start_time
         if settings.target == "websocket" or settings.target == "all":
             start_time = time.time()
-            websocket_transcription = transcribe_file_websocket(
-                filepath, settings.overwrite_api_key
-            )
+            if settings.use_partials_for_websocket:
+                websocket_partial_result = evaluate_partial_websocket(
+                    filepath, " ".join(expected), settings.debug
+                )
+            else:
+                websocket_transcription = transcribe_file_websocket(
+                    filepath, settings.overwrite_api_key, settings.debug
+                )
             # During transcription we wait for timeout once
             # Therefore we subtract it from the recorded transcription time
             websocket_duration = (
                 time.time() - start_time - TRANSCRIPTION_WEBSOCKET_TIMEOUT
             )
-        expected = transform_default(get_expected_transcription(filepath))
         if settings.debug:
             print(f"Expected: {expected}")
 
@@ -82,6 +74,12 @@ def benchmark(settings):
             (websocket_transcription, websocket_duration, "websocket"),
         ]:
             transcription, duration, method_key = val
+
+            if settings.use_partials_for_websocket and method_key == "websocket":
+                results[f"wer_{method_key}"] += [websocket_partial_result]
+                results[f"duration_{method_key}"] += [duration]
+                continue
+
             if transcription is None or duration is None:
                 results[f"wer_{method_key}"] += [None]
                 results[f"duration_{method_key}"] += [None]
@@ -95,12 +93,18 @@ def benchmark(settings):
                 results[f"wer_{method_key}"] += [ERR_CODE]
                 continue
 
-            transcription = transform_default(transcription)
+            transcription = TRANSFORM_DEFAULT(transcription)
             if settings.debug:
                 print(f"Received({method_key}): {transcription}")
 
             curr_wer = jiwer.wer(" ".join(transcription), " ".join(expected))
             results[f"wer_{method_key}"] += [curr_wer]
+
+    if settings.scale_percentage != "100":
+        print(
+            f"Premature termination after {int(limit)} (dataset total length: {len(audio_files)}) evaluated audios. This was caused by the set limit percentage of {settings.scale_percentage}"
+        )
+
     render_table(results, export=settings.export_markdown)
 
 
@@ -115,6 +119,12 @@ if __name__ == "__main__":
         default="small",
         choices=["small", "big"],
         help="Set the dataset to use. Affects duration and accuracy of benchmark",
+    )
+    parser.add_argument(
+        "--scale-percentage",
+        "-sp",
+        default="100",
+        help="Percentage of dataset that should be used. Allows for running the big dataset partially.",
     )
     parser.add_argument(
         "--target",
@@ -143,5 +153,10 @@ if __name__ == "__main__":
         "--export-markdown",
         action="store_true",
         help="Export table as markdown to results.md",
+    )
+    parser.add_argument(
+        "--use-partials-for-websocket",
+        action="store_true",
+        help="Overwrite websocket benchmark to the live partials and finals instead of the final transcription export. This will calculate the average over all partials and finals when compared to the whole expected text. Therefore this is NOT(!) meant to be compared to REST WER or the final export ws WER.",
     )
     benchmark(parser.parse_args())

--- a/tooling/helpers/WER_helper.py
+++ b/tooling/helpers/WER_helper.py
@@ -1,0 +1,22 @@
+from jiwer.transforms import (
+    Compose,
+    RemoveMultipleSpaces,
+    Strip,
+    ToLowerCase,
+    ExpandCommonEnglishContractions,
+    RemoveKaldiNonWords,
+    RemoveWhiteSpace,
+    ReduceToSingleSentence,
+)
+
+TRANSFORM_DEFAULT = Compose(
+    [
+        ToLowerCase(),
+        ExpandCommonEnglishContractions(),
+        RemoveKaldiNonWords(),
+        RemoveWhiteSpace(replace_by_space=True),
+        RemoveMultipleSpaces(),
+        Strip(),
+        ReduceToSingleSentence(),
+    ]
+)

--- a/tooling/helpers/websocket_helper.py
+++ b/tooling/helpers/websocket_helper.py
@@ -98,9 +98,10 @@ async def __transcribe_file_websocket(filepath: str, debug=False) -> Dict:
                             if debug:
                                 print(f"Partial: {d['partial']}")
                         elif "text" in d:
-                            result["partials"].append(d["text"])
-                            if debug:
-                                print(f"Final: {d['text']}")
+                            pass
+                            # result["partials"].append(d["text"])
+                            # if debug:
+                            # print(f"Final: {d['text']}")
 
                     except json.JSONDecodeError:
                         pass


### PR DESCRIPTION
# Changes:
- add benchmarking option to benchmark partials
- add option to only run a certain percentage of a dataset instead of the whole dataset

## Note

This approach to benchmarking might be a bit suboptimal and has to be tested further. This is just a quick solution for evaluating #132 .
The test to check whether this yields a somewhat reasonable result was the following:
Benchmark partials of the actual transcription (top) vs. benchmark of strings only consisting of the letter "a" but with the same length as the transcription partials.
![image](https://github.com/user-attachments/assets/b505be14-a885-4ede-9a95-25f027a4afda)

