### PR TITLE
chore(repo): cleanup caching architecture

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           pip install -r ./requirements.txt
 
       - name: Setup FFmpeg
-        uses: AnimMouse/setup-ffmpeg@v3
+        uses: AnimMouse/setup-ffmpeg@v1
         with:
           version: 5.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
-
-      - name: Cache Python dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
+          cache: 'pip'
 
       - name: Install dependencies 
         run: |
@@ -31,7 +25,7 @@ jobs:
           pip install -r ./requirements.txt
 
       - name: Setup FFmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
+        uses: AnimMouse/setup-ffmpeg@v3
         with:
           version: 5.1
 


### PR DESCRIPTION
# Changes
- cleanup pip caching -> old solution always had a no-cache-hit warning

Closes #137 